### PR TITLE
Use tox for the local dev testing setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.6"
 sudo: false
 install:
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
+  - pip install tox-travis
 script:
-  - pytest tests.py
+  - tox

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Choose a random restaurant from a raw list: `!resto pick`
 Choose a random restaurant from yelp around your position: `!resto yelp`
 
 ## Run tests
+
 ```
-pip install -r requirements.txt
-pip install -r dev-requirements.txt
-pytest tests.py
+tox
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36
+envlist = py34, py35, py36
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py33, py34, py35, py36
+skipsdist = True
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rdev-requirements.txt
+
+commands =
+    py.test tests.py


### PR DESCRIPTION
This fixes tests that would fail locally because the virtual env
was being inspected and causing issues with autodiscovered
errbot backends.

This also means the tests will run for all available python versions
on the dev machine, as opposed to running only on the current version.